### PR TITLE
deps: updates wazero to 1.0.0-pre.8

### DIFF
--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -73,7 +73,7 @@ func Test_EndToEnd(t *testing.T) {
 				defer free.Call(testCtx, namePtr)
 
 				// The pointer is a linear memory offset, which is where we write the name.
-				ok := guest.Memory().Write(testCtx, uint32(namePtr), []byte(name))
+				ok := guest.Memory().Write(uint32(namePtr), []byte(name))
 				require.True(t, ok, "out of memory writing %s", name)
 
 				// Finally, we get the greeting message "greet" printed. This shows how to
@@ -86,7 +86,7 @@ func Test_EndToEnd(t *testing.T) {
 				greetingSize := uint32(ptrSize[0])
 
 				// The pointer is a linear memory offset, which is where we write the name.
-				bytes, ok := guest.Memory().Read(testCtx, greetingPtr, greetingSize)
+				bytes, ok := guest.Memory().Read(greetingPtr, greetingSize)
 				require.True(t, ok, "out of memory reading greeting(%d, %d)", greetingPtr, greetingSize)
 
 				require.Equal(t, "Hello, foo!", string(bytes))

--- a/internal/e2e/go.mod
+++ b/internal/e2e/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/stretchr/testify v1.8.0
-	github.com/tetratelabs/wazero v1.0.0-pre.3
+	github.com/tetratelabs/wazero v1.0.0-pre.8
 )
 
 require (

--- a/internal/e2e/go.sum
+++ b/internal/e2e/go.sum
@@ -8,8 +8,8 @@ github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSS
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/tetratelabs/wazero v1.0.0-pre.3 h1:Z5fbogMUGcERzaQb9mQU8+yJSy0bVvv2ce3dfR4wcZg=
-github.com/tetratelabs/wazero v1.0.0-pre.3/go.mod h1:M8UDNECGm/HVjOfq0EOe4QfCY9Les1eq54IChMLETbc=
+github.com/tetratelabs/wazero v1.0.0-pre.8 h1:Ir82PWj79WCppH+9ny73eGY2qv+oCnE3VwMY92cBSyI=
+github.com/tetratelabs/wazero v1.0.0-pre.8/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0-pre.8](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.8) which notably

* Changes the `Instantiate` signature, which no longer requires
  an explicit `Runtime` instance.
* Changes the `Memory` `Read`/`Write` signatures, which no longer
  take a `Context`

Signed-off-by: Edoardo Vacchi <evacchi@users.noreply.github.com>
